### PR TITLE
Fix Vue.js code generator and review other generators

### DIFF
--- a/resources/script.js
+++ b/resources/script.js
@@ -275,8 +275,8 @@ function buildVueCode(company, phoneDigits, greeting, outerMessage) {
       </div>
       <div class="whatswidget-conversation-message">{{ finalGreeting }}</div>
       <div class="whatswidget-conversation-cta">
-        <a :href="\`https://web.whatsapp.com/send?phone=${phoneDigits}\`" target="_blank" rel="noopener noreferrer" class="whatswidget-cta whatswidget-cta-desktop">Send message</a>
-        <a :href="\`https://wa.me/${phoneDigits}\`" target="_blank" rel="noopener noreferrer" class="whatswidget-cta whatswidget-cta-mobile">Send message</a>
+        <a :href="`https://web.whatsapp.com/send?phone=\${finalPhoneNo}`" target="_blank" rel="noopener noreferrer" class="whatswidget-cta whatswidget-cta-desktop">Send message</a>
+        <a :href="`https://wa.me/\${finalPhoneNo}`" target="_blank" rel="noopener noreferrer" class="whatswidget-cta whatswidget-cta-mobile">Send message</a>
       </div>
     </div>
     <div v-if="!isOpen" class="whatswidget-conversation-message-outer" @click="isOpen = true">


### PR DESCRIPTION
The user reported that some of the code generation options were not working, specifically React and Vue.

This change fixes a bug in the `buildVueCode` function where the generated Vue component was not correctly using its `phoneNo` prop. The template was hardcoding the phone number from the form instead of using the component's data property. The fix ensures the generated component is reusable and respects the props passed to it.

I have also thoroughly reviewed the code generation functions for React, Blazor, and HTML, and I have not found any logical errors. The generated code for these frameworks appears to be correct. Without the ability to run the application and reproduce the user's issue with React, I have focused on fixing the identifiable bug in the Vue generator.