### PR TITLE
feat: Convert greeting and outer message to dropdowns

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,12 +67,20 @@
 
               <div class="mb-3">
                 <label class="form-label">Greeting Message (inside chat)</label>
-                <input class="form-control" id="greeting" placeholder="How can we help you?" value="How can we help you?" required>
+                <select class="form-control" id="greeting" required>
+                  <option value="How can we help you?">How can we help you?</option>
+                  <option value="Hello! How can I assist you today?">Hello! How can I assist you today?</option>
+                  <option value="Have a question? We're here to help.">Have a question? We're here to help.</option>
+                </select>
               </div>
 
               <div class="mb-3">
                 <label class="form-label">Outer quick message</label>
-                <input class="form-control" id="outerMessage" placeholder="Need Help? Chat With Us." value="Need Help? Chat With Us.">
+                <select class="form-control" id="outerMessage">
+                  <option value="Need Help? Chat With Us.">Need Help? Chat With Us.</option>
+                  <option value="Questions? Chat Now!">Questions? Chat Now!</option>
+                  <option value="Live Chat">Live Chat</option>
+                </select>
                 <div class="form-text small-muted">This text appears on the little outer bubble.</div>
               </div>
 

--- a/resources/script.js
+++ b/resources/script.js
@@ -598,8 +598,7 @@ document.getElementById('downloadBtn').addEventListener('click', function () {
 
 
 // initial sample preview
-updatePreview('Business/Brand Name', sanitizePhone('+233123456789'), 'How can we help you?', 'Need Help? Chat With Us.');
 document.getElementById('companyName').value = 'Business/Brand Name';
 document.getElementById('phoneNumber').value = '+233 12 345 6789';
-document.getElementById('greeting').value = 'How can we help you?';
-document.getElementById('outerMessage').value = 'Need Help? Chat With Us.';
+// trigger initial preview
+document.getElementById('widgetForm').dispatchEvent(new Event('submit'));


### PR DESCRIPTION
Replaced the input fields for the greeting and outer quick messages with dropdown menus to provide users with a predefined set of options.

- Modified `index.html` to change the `<input>` elements to `<select>` elements with appropriate options.
- Updated `resources/script.js` to ensure the initial preview reflects the default dropdown values.