### PR TITLE
refactor: Resize logo to 100x100 pixels

### DIFF
--- a/resources/script.js
+++ b/resources/script.js
@@ -61,8 +61,8 @@ const widgetCss = `
   align-items: center;
 }
 .whatswidget-logo {
-  width: 40px;
-  height: 40px;
+  width: 100px;
+  height: 100px;
   border-radius: 50%;
   margin-right: 10px;
   object-fit: cover;


### PR DESCRIPTION
Updated the CSS for the widget to resize the brand logo to 100x100 pixels as requested.