### PR TITLE
refactor: Resize logo to 30x30 pixels

### DIFF
--- a/resources/script.js
+++ b/resources/script.js
@@ -61,8 +61,8 @@ const widgetCss = `
   align-items: center;
 }
 .whatswidget-logo {
-  width: 100px;
-  height: 100px;
+  width: 30px;
+  height: 30px;
   border-radius: 50%;
   margin-right: 10px;
   object-fit: cover;


### PR DESCRIPTION
Updated the CSS for the widget to resize the brand logo to 30x30 pixels to better fit the chat header.