### PR TITLE
fix: Correctly size logo in live preview

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -96,11 +96,21 @@ pre[id^="generated-"] {
 
 .whatswidget-conversation-header {
   background-color: #25D366;
-  padding: 10px 25px;
+  padding: 10px;
   box-shadow: 0px 1px #00000029;
   font-weight: 600;
   border-top-left-radius: 15px;
   border-top-right-radius: 15px;
+  display: flex;
+  align-items: center;
+}
+
+.whatswidget-logo {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  margin-right: 10px;
+  object-fit: cover;
 }
 
 .whatswidget-conversation-message {


### PR DESCRIPTION
The logo was appearing too large in the live preview because the CSS for the preview was not updated. This change adds the necessary styles to `resources/style.css` to ensure the logo is correctly sized at 30x30 pixels in the preview, matching the generated code.